### PR TITLE
Adds ability to undo and redo movement actions

### DIFF
--- a/Assets/Scripts/Targets/TargetMoveIntent.cs
+++ b/Assets/Scripts/Targets/TargetMoveIntent.cs
@@ -1,0 +1,9 @@
+﻿using UnityEngine;
+
+namespace NotReaper.Targets {
+	public class TargetMoveIntent {
+		public Target target;
+		public Vector3 startingPosition;
+		public Vector3 intendedPosition;
+	}
+}

--- a/Assets/Scripts/Timeline.cs
+++ b/Assets/Scripts/Timeline.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
@@ -405,6 +405,24 @@ namespace NotReaper {
 			} else {
 				target.UpdateSustainBeatLength(Mathf.Max(target.beatLength -= (480 / beatSnap) * 4f, 0));
 			}
+		}
+
+		public void MoveGridTargets(List<TargetMoveIntent> intents, bool genUndoAction = true, bool clearRedoActions = true) {
+
+			if (genUndoAction) {
+				var action = new NRActionGridMoveNotes();
+				action.targetGridMoveIntents = intents;
+				Tools.undoRedoManager.AddAction(action, clearRedoActions);
+			}
+
+			intents.ForEach(intent => {
+				var newPos = intent.intendedPosition;
+				intent.target.gridTargetIcon.transform.localPosition = new Vector3(
+					newPos.x,
+					newPos.y,
+					newPos.z
+				);
+			});
 		}
 
 		// Invert the selected targets' colour

--- a/Assets/Scripts/Tools/UndoRedoManager.cs
+++ b/Assets/Scripts/Tools/UndoRedoManager.cs
@@ -100,7 +100,15 @@ namespace NotReaper.Tools {
 					break;
 
 				case NRActionGridMoveNotes a:
-					// TODO
+					var intents = new List<TargetMoveIntent>();
+					a.targetGridMoveIntents.ForEach(intent => {
+						var undoIntent = new TargetMoveIntent();
+						undoIntent.target = intent.target;
+						undoIntent.intendedPosition = intent.startingPosition;
+						undoIntent.startingPosition = intent.intendedPosition;
+						intents.Add(undoIntent);
+					});
+					timeline.MoveGridTargets(intents, false);
 					break;
 
 				case NRActionSwapNoteColors a:
@@ -146,7 +154,7 @@ namespace NotReaper.Tools {
 					break;
 
 				case NRActionGridMoveNotes a:
-					// TODO
+					timeline.MoveGridTargets(a.targetGridMoveIntents, true, false);
 					break;
 
 				case NRActionSwapNoteColors a:
@@ -246,8 +254,7 @@ namespace NotReaper.Tools {
 	}
 
 	public class NRActionGridMoveNotes : NRAction {
-		public List<Vector2> orderedPreviousPositions = new List<Vector2>();
-		public List<Target> affectedTargets = new List<Target>();
+		public List<TargetMoveIntent> targetGridMoveIntents = new List<TargetMoveIntent>();
 	}
 
 	public class NRActionSwapNoteColors : NRAction {


### PR DESCRIPTION
This was implemented with a TargetMoveIntent object which encapsulates the target, starting position and target position. Although the DragSelect class technically moves the target in real-time, the new Timeline::MoveGridTargets function also sets the positions for the undo / redo actions. The DragSelect could potentially now just show transparent targets in lieu of actually updating the state of the targets.