### PR TITLE
Add: undo and redo handling of pasting notes

### DIFF
--- a/Assets/Scripts/Targets/TargetMoveIntent.cs.meta
+++ b/Assets/Scripts/Targets/TargetMoveIntent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e441223b90be8494bacf4abd7fecc5e6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Tools/DragSelect/DragSelect.cs
+++ b/Assets/Scripts/Tools/DragSelect/DragSelect.cs
@@ -30,8 +30,7 @@ namespace NotReaper.Tools {
 
 		public LayerMask notesLayer;
 
-		public List<Target> clipboardNotes = new List<Target>();
-		public float clipboardBeatTime = 0f;
+		public List<Cue> clipboardNotes = new List<Cue>();
 
 		private List<TargetMoveIntent> gridTargetMoveIntents = new List<TargetMoveIntent>();
 
@@ -200,37 +199,13 @@ namespace NotReaper.Tools {
 			};
 
 			Action copy = () => {
-				clipboardNotes = new List<Target>();
-				clipboardNotes = timeline.selectedNotes;
-
-				if (clipboardNotes.Count < 1) return;
-
-				clipboardBeatTime = Mathf.Infinity;
-
-				//Find the soonest target in the selection
-				foreach (Target target in clipboardNotes) {
-					float pos = target.gridTargetIcon.transform.localPosition.z;
-					if (pos < clipboardBeatTime) {
-						clipboardBeatTime = pos;
-					}
-				}
+				clipboardNotes = new List<Cue>();
+				timeline.selectedNotes.ForEach(note => clipboardNotes.Add(NotePosCalc.ToCue(note, 0, false)));
 			};
 
 			Action paste = () => {
 				timeline.DeselectAllTargets();
-
-				List<Target> pasteNotes = new List<Target>();
-
-				float diff = Timeline.BeatTime() - clipboardBeatTime;
-
-				foreach (Target target in clipboardNotes) {
-					target.gridTargetPos.z += diff;
-					pasteNotes.Add(target);
-
-				}
-
-				clipboardBeatTime = Timeline.BeatTime();
-				timeline.AddTargets(clipboardNotes, true, true);
+				timeline.PasteCues(clipboardNotes, Timeline.BeatTime());
 			};
 
 			if (Input.GetKeyDown(KeyCode.Delete)) {

--- a/Assets/Scripts/Tools/UndoRedoManager.cs
+++ b/Assets/Scripts/Tools/UndoRedoManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using NotReaper.Grid;
 using NotReaper.Targets;
 using NotReaper.UserInput;
+using NotReaper.Models;
 using UnityEngine;
 using UnityEngine.EventSystems;
 
@@ -96,7 +97,7 @@ namespace NotReaper.Tools {
 					break;
 
 				case NRActionPasteNotes a:
-					// TODO
+					timeline.DeleteTargets(a.pastedTargets, false);
 					break;
 
 				case NRActionGridMoveNotes a:
@@ -150,7 +151,7 @@ namespace NotReaper.Tools {
 					break;
 
 				case NRActionPasteNotes a:
-					// TODO
+					timeline.PasteCues(a.newCues, a.pasteBeatTime, true, false);
 					break;
 
 				case NRActionGridMoveNotes a:
@@ -250,7 +251,9 @@ namespace NotReaper.Tools {
 	}
 
 	public class NRActionPasteNotes : NRAction {
-		public List<Target> affectedTargets = new List<Target>();
+		public List<Cue> newCues = new List<Cue>();
+		public List<Target> pastedTargets = new List<Target>();
+		public float pasteBeatTime;
 	}
 
 	public class NRActionGridMoveNotes : NRAction {


### PR DESCRIPTION
This uses the Cue system to store data representations of targets to paste rather than the direct references. This means that the state of the initially copied targets does not matter (e.g. you can copy and delete or copy and move before pasting and the clipboard will persist through any state changes).