### PR TITLE
Improved target selection logic

### DIFF
--- a/Assets/Scripts/Grid/HoverTarget.cs
+++ b/Assets/Scripts/Grid/HoverTarget.cs
@@ -66,7 +66,6 @@ namespace NotReaper.Grid {
                         //return;
                     //}
                     //lastPos = newPos;
-                    Debug.Log(newPos);
                     transform.position = newPos;
                     //transform.position = Vector3.SmoothDamp(transform.position, newPos, ref velocity, 0.3f);
                     break;

--- a/Assets/Scripts/UserInput/MouseUtil.cs
+++ b/Assets/Scripts/UserInput/MouseUtil.cs
@@ -1,0 +1,31 @@
+﻿using System.Linq;
+using UnityEngine;
+using NotReaper.Targets;
+
+namespace NotReaper.UserInput {
+	public class MouseUtil : MonoBehaviour {
+		public static TargetIcon[] IconsUnderMouse(LayerMask mask) {
+			Ray ray = Camera.main.ScreenPointToRay(Input.mousePosition);
+			ray.origin = new Vector3(ray.origin.x, ray.origin.y, -1.7f);
+			ray.direction = Vector3.forward;
+			//TODO: Tweakable selection distance for raycast
+			//Box collider size currently 2.2
+
+			var results = Physics.RaycastAll(ray, 3.4f, mask);
+			return results
+				.Where(result => result.transform.GetComponent<TargetIcon>() != null)
+				.OrderBy(result => {
+					// sort by the distance from the centre of the timeline (closest = 0)
+					var target = result.transform.GetComponent<TargetIcon>();
+
+					var isTimeline = (result.transform.position.y > 4.18);     // yes, this is how we're determining this. I'm sorry.
+					var distance = isTimeline ?
+						Mathf.Abs(target.transform.localPosition.x) :
+						Mathf.Abs(target.transform.position.z);
+					return distance;
+				})
+				.Select(result => result.transform.GetComponent<TargetIcon>())
+				.ToArray();
+		}
+	}
+}


### PR DESCRIPTION
This PR adds all targets to the response of a mouse raycast, ordered by temporal distance. This prioritises the notes closet to you on the timeline for selection logic.

This has been implemented in its own little util class but delete does not currently use it.