### PR TITLE
Initial .audica creation fixes

### DIFF
--- a/Assets/Scripts/IO/AudicaGenerator.cs
+++ b/Assets/Scripts/IO/AudicaGenerator.cs
@@ -71,6 +71,8 @@ namespace NotReaper.IO {
 				archive.AddEntry("song.desc", Path.Combine(workFolder, "song.desc"));
 				archive.AddEntry("song.mid", Path.Combine(workFolder, "song.mid"));
 				archive.AddEntry("song.mogg", Path.Combine(workFolder, "song.mogg"));
+				
+				Directory.CreateDirectory(Path.Combine(Application.dataPath, "saves"));
 				archive.SaveTo(Path.Combine(Application.dataPath, "saves", songID + ".audica"), SharpCompress.Common.CompressionType.None);
 			}
 

--- a/Assets/Scripts/Timing/UITiming.cs
+++ b/Assets/Scripts/Timing/UITiming.cs
@@ -97,7 +97,7 @@ namespace NotReaper.Timing {
             if (loadedSong == null) return;
             Debug.Log(loadedSong);
             trimAudio.SetAudioLength(loadedSong, Path.Combine(Application.streamingAssetsPath, "FFMPEG", "output.ogg") , offset, bpm);
-            string path = AudicaGenerator.Generate(Path.Combine(Application.streamingAssetsPath, "FFMPEG", "output.ogg"), "tempsongid-yay", "yourawesomesong", "circuitlord", bpm, "songendevent", "you", 0);
+            string path = AudicaGenerator.Generate(Path.Combine(Application.streamingAssetsPath, "FFMPEG", "output.ogg"), Path.GetFileNameWithoutExtension(loadedSong), "yourawesomesong", "circuitlord", bpm, "songendevent", "you", 0);
             timeline.LoadAudicaFile(false, path);
         }
 

--- a/Assets/Scripts/Timing/UITiming.cs
+++ b/Assets/Scripts/Timing/UITiming.cs
@@ -97,7 +97,8 @@ namespace NotReaper.Timing {
             if (loadedSong == null) return;
             Debug.Log(loadedSong);
             trimAudio.SetAudioLength(loadedSong, Path.Combine(Application.streamingAssetsPath, "FFMPEG", "output.ogg") , offset, bpm);
-            AudicaGenerator.Generate(Path.Combine(Application.streamingAssetsPath, "FFMPEG", "output.ogg"), "tempsongid-yay", "yourawesomesong", "circuitlord", bpm, "songendevent", "you", 0);
+            string path = AudicaGenerator.Generate(Path.Combine(Application.streamingAssetsPath, "FFMPEG", "output.ogg"), "tempsongid-yay", "yourawesomesong", "circuitlord", bpm, "songendevent", "you", 0);
+            timeline.LoadAudicaFile(false, path);
         }
 
         public void UpdateUIValues() {


### PR DESCRIPTION
This PR fixes several issues when creating a new audica file for the first time.

## Fixes
- `/saves/` folder will always be created if it doesn't exist
- Generating the audica file will load it into the editor
- Generated name is based off the loaded .ogg file name