### PR TITLE
Bugfix #19: Fixed zooming not scaling sustain bars

### DIFF
--- a/Assets/Scripts/Targets/TargetIcon.cs
+++ b/Assets/Scripts/Targets/TargetIcon.cs
@@ -163,21 +163,14 @@ namespace NotReaper.Targets {
 
         public void SetSustainLength(float beatLength) {
             
-            //float scale = Timeline.scale / 20f;
-            //float diff = 1 - scale;
-            //scale = 1 + diff;
-
-            
-
-
-           // Debug.Log(scale);
+            float scale = 20.0f / Timeline.scale;
 
             foreach (LineRenderer l in gameObject.GetComponentsInChildren<LineRenderer>(true)) {
                 if (beatLength >= 1) {
                     l.SetPosition(0, new Vector3(0.0f, 0.0f, 0.0f));
                     l.SetPosition(1, new Vector3(0.0f, sustainDirection, 0.0f));
                     beatLength = beatLength / 480;
-                    l.SetPosition(2, new Vector3((beatLength / 0.7f) * 1.0f, sustainDirection, 0.0f));
+                    l.SetPosition(2, new Vector3((beatLength / 0.7f) * scale, sustainDirection, 0.0f));
                 } else {
                     l.SetPosition(0, new Vector3(0.0f, 0.0f, 0.0f));
                     l.SetPosition(1, new Vector3(0.0f, 0.0f, 0.0f));

--- a/Assets/Scripts/Timeline.cs
+++ b/Assets/Scripts/Timeline.cs
@@ -1074,11 +1074,17 @@ namespace NotReaper {
 
 			//spectrogram.localScale = new Vector3(aud.clip.length / 2 * bpm / 60 / (newScale / 20f), 1, 1);
 
-			timelineTransformParent.transform.localScale *= (float) scale / newScale;
+			Vector3 timelineTransformScale = timelineTransformParent.transform.localScale;
+			timelineTransformScale.x *= (float) scale / newScale;
+
+			timelineTransformParent.transform.localScale = timelineTransformScale;
+
 			targetScale *= (float) newScale / scale;
 			// fix scaling on all notes
 			foreach (Transform note in timelineTransformParent.transform) {
-				note.localScale = targetScale * Vector3.one;
+				Vector3 noteScale = note.localScale;
+				noteScale.x = targetScale;
+				note.localScale = noteScale;
 			}
 
 
@@ -1087,7 +1093,7 @@ namespace NotReaper {
 			foreach (Target target in orderedNotes) {
 				if (target.behavior == TargetBehavior.Hold) {
 					//TODO: Fix sustain line scaling when scaling timeline
-					//target.timelineTargetIcon.SetSustainLength(target.beatLength);
+					target.timelineTargetIcon.SetSustainLength(target.beatLength);
 				}
 			}
 		}


### PR DESCRIPTION
This PR fixes #19, we no longer scale the Y-axis, and we scale the sustain duration relative to the current scale.

## Screenshot
![scrolly](https://user-images.githubusercontent.com/830434/65013718-03801180-d8d1-11e9-954e-1acbdc282eba.gif)
