### PR TITLE
New action system

### DIFF
--- a/Assets/Scripts/Targets/Target.cs
+++ b/Assets/Scripts/Targets/Target.cs
@@ -21,9 +21,9 @@ namespace NotReaper.Targets {
 
 
 		//Events and stuff:
-		public event Action<Target, bool, bool> DeleteNoteEvent;
-		public void DeleteNote(bool genUndoAction = true) {
-			DeleteNoteEvent(this, genUndoAction, true);
+		public event Action<Target> DeleteNoteEvent;
+		public void DeleteNote() {
+			DeleteNoteEvent(this);
 		}
 
 		public event Action<Target> TargetEnterLoadedNotesEvent;

--- a/Assets/Scripts/Targets/TargetData.cs
+++ b/Assets/Scripts/Targets/TargetData.cs
@@ -1,0 +1,42 @@
+using System;
+using UnityEngine;
+using NotReaper.Models;
+using NotReaper.Grid;
+
+namespace NotReaper.Targets {
+
+	public class TargetData {
+		public float x; 
+		public float y;
+		public float beatTime;
+		public float beatLength = 0.25f;
+		public TargetVelocity velocity = TargetVelocity.Standard;
+		public TargetHandType handType = TargetHandType.Left;
+		public TargetBehavior behavior = TargetBehavior.Standard;
+
+		public TargetData() {
+
+		}
+
+		public TargetData(Target target) {
+			x = target.gridTargetIcon.transform.localPosition.x;
+			y = target.gridTargetIcon.transform.localPosition.y;
+			beatTime = target.gridTargetIcon.transform.localPosition.z;
+			beatLength = target.beatLength;
+			velocity = target.velocity;
+			handType = target.handType;
+			behavior = target.behavior;
+		}
+
+		public TargetData(Cue cue, float offset) {
+			Vector2 pos = NotePosCalc.PitchToPos(cue);
+			x = pos.x;
+			y = pos.y;
+			beatTime = (cue.tick - offset) / 480f;
+			beatLength = cue.tickLength;
+			velocity = cue.velocity;
+			handType = cue.handType;
+			behavior = cue.behavior;
+		}
+	};
+}

--- a/Assets/Scripts/Targets/TargetData.cs.meta
+++ b/Assets/Scripts/Targets/TargetData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e7dc87ec56a6cb0469a009674fc3f3da
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Targets/TargetIcon.cs
+++ b/Assets/Scripts/Targets/TargetIcon.cs
@@ -43,10 +43,10 @@ namespace NotReaper.Targets {
         /// <summary>
         /// For when the note is right clicked on. Bool is for if it should gen an undo action
         /// </summary>
-        public event Action<bool> OnTryRemoveEvent;
+        public event Action OnTryRemoveEvent;
 
         public void OnTryRemove() {
-            OnTryRemoveEvent(true);
+            OnTryRemoveEvent();
         }
 
         public void Remove() {

--- a/Assets/Scripts/Timeline.cs
+++ b/Assets/Scripts/Timeline.cs
@@ -105,41 +105,6 @@ namespace NotReaper {
 		[HideInInspector] public bool hover = false;
 		public bool paused = true;
 
-		public class TargetData {
-			public float x; 
-			public float y;
-			public float beatTime;
-			public float beatLength = 0.25f;
-			public TargetVelocity velocity = TargetVelocity.Standard;
-			public TargetHandType handType = TargetHandType.Left;
-			public TargetBehavior behavior = TargetBehavior.Standard;
-
-			public TargetData() {
-
-			}
-
-			public TargetData(Target target) {
-				x = target.gridTargetIcon.transform.localPosition.x;
-				y = target.gridTargetIcon.transform.localPosition.y;
-				beatTime = target.gridTargetIcon.transform.localPosition.z;
-				beatLength = target.beatLength;
-				velocity = target.velocity;
-				handType = target.handType;
-				behavior = target.behavior;
-			}
-
-			public TargetData(Cue cue) {
-				Vector2 pos = NotePosCalc.PitchToPos(cue);
-				x = pos.x;
-				y = pos.y;
-				beatTime = (cue.tick - offset) / 480f;
-				beatLength = cue.tickLength;
-				velocity = cue.velocity;
-				handType = cue.handType;
-				behavior = cue.behavior;
-			}
-		};
-
 		//Tools
 		private void Start() {
 
@@ -203,7 +168,7 @@ namespace NotReaper {
 
 		//When loading from cues, use this.
 		public void AddTarget(Cue cue) {
-			TargetData data = new TargetData(cue);
+			TargetData data = new TargetData(cue, offset);
 			AddTargetFromAction(data);
 		}
 
@@ -219,7 +184,7 @@ namespace NotReaper {
 			float tempTime = GetClosestBeatSnapped(DurationToBeats(time));
 
 			foreach (Target target in Timeline.loadedNotes) {
-				if (target.gridTargetPos.z == tempTime && (target.handType == EditorInput.selectedHand) && (EditorInput.selectedTool != EditorTool.Melee)) return null;
+				if (target.gridTargetPos.z == tempTime && (target.handType == EditorInput.selectedHand) && (EditorInput.selectedTool != EditorTool.Melee)) return;
 			}
 
 			data.beatTime = GetClosestBeatSnapped(DurationToBeats(time));
@@ -448,7 +413,7 @@ namespace NotReaper {
 		public void PasteCues(List<Cue> cues, float pasteBeatTime) {
 
 			// paste new targets in the original locations
-			var targetDataList = cues.Select(cue => new TargetData(cue)).ToList();
+			var targetDataList = cues.Select(cue => new TargetData(cue, offset)).ToList();
 
 			// find the soonest target in the selection
 			float earliestTargetBeatTime = Mathf.Infinity;
@@ -636,7 +601,7 @@ namespace NotReaper {
 
 			for (int i = 0; i < 100; i++) {
 				cue.tick = (480 * i) + tickOffset;
-				AddTargetFromAction(new TargetData(cue));
+				AddTargetFromAction(new TargetData(cue, offset));
 			}
 
 			//time = 0;

--- a/Assets/Scripts/Tools/DragSelect/DragSelect.cs
+++ b/Assets/Scripts/Tools/DragSelect/DragSelect.cs
@@ -213,7 +213,7 @@ namespace NotReaper.Tools {
 			// TODO: Move these actions into timeline to record sane undo actions!
 			Action delete = () => {
 				if (timeline.selectedNotes.Count > 0) {
-					timeline.DeleteTargets(timeline.selectedNotes, true, true);
+					timeline.DeleteTargets(timeline.selectedNotes);
 				}
 				timeline.selectedNotes = new List<Target>();
 			};

--- a/Assets/Scripts/Tools/UndoRedoManager.cs
+++ b/Assets/Scripts/Tools/UndoRedoManager.cs
@@ -77,7 +77,7 @@ namespace NotReaper.Tools {
 	}
 
 	public class NRActionAddNote : NRAction {
-		public Timeline.TargetData targetData;
+		public TargetData targetData;
 
 		public override void DoAction(Timeline timeline) {
 			timeline.AddTargetFromAction(targetData);
@@ -88,7 +88,7 @@ namespace NotReaper.Tools {
 	}
 
 	public class NRActionMultiAddNote : NRAction {
-		public List<Timeline.TargetData> affectedTargets = new List<Timeline.TargetData>();
+		public List<TargetData> affectedTargets = new List<TargetData>();
 
 		public override void DoAction(Timeline timeline) {
 			affectedTargets.ForEach(targetData => { timeline.AddTargetFromAction(targetData); });
@@ -99,7 +99,7 @@ namespace NotReaper.Tools {
 	}
 	
 	public class NRActionRemoveNote : NRAction {
-		public Timeline.TargetData targetData;
+		public TargetData targetData;
 
 		public override void DoAction(Timeline timeline) {
 			timeline.DeleteTargetFromAction(targetData);
@@ -110,7 +110,7 @@ namespace NotReaper.Tools {
 	}
 	
 	public class NRActionMultiRemoveNote : NRAction {
-		public List<Timeline.TargetData> affectedTargets = new List<Timeline.TargetData>();
+		public List<TargetData> affectedTargets = new List<TargetData>();
 
 		public override void DoAction(Timeline timeline) {
 			affectedTargets.ForEach(targetData => { timeline.DeleteTargetFromAction(targetData); });
@@ -124,12 +124,12 @@ namespace NotReaper.Tools {
 		public TargetDataMoveIntent() {}
 
 		public TargetDataMoveIntent(TargetMoveIntent intent) {
-			targetData = new Timeline.TargetData(intent.target);
+			targetData = new TargetData(intent.target);
 			startingPosition = intent.startingPosition;
 			intendedPosition = intent.intendedPosition;
 		}
 
-		public Timeline.TargetData targetData;
+		public TargetData targetData;
 		public Vector3 startingPosition;
 		public Vector3 intendedPosition;
 	}
@@ -183,7 +183,7 @@ namespace NotReaper.Tools {
 	}
 
 	public class NRActionSwapNoteColors : NRAction {
-		public List<Timeline.TargetData> affectedTargets = new List<Timeline.TargetData>();
+		public List<TargetData> affectedTargets = new List<TargetData>();
 
 		public override void DoAction(Timeline timeline) {
 			affectedTargets.ForEach(targetData => {
@@ -208,7 +208,7 @@ namespace NotReaper.Tools {
 	}
 
 	public class NRActionHFlipNotes : NRAction {
-		public List<Timeline.TargetData> affectedTargets = new List<Timeline.TargetData>();
+		public List<TargetData> affectedTargets = new List<TargetData>();
 
 		public override void DoAction(Timeline timeline) {
 			affectedTargets.ForEach(targetData => {
@@ -229,7 +229,7 @@ namespace NotReaper.Tools {
 	}
 
 	public class NRActionVFlipNotes : NRAction {
-		public List<Timeline.TargetData> affectedTargets = new List<Timeline.TargetData>();
+		public List<TargetData> affectedTargets = new List<TargetData>();
 
 		public override void DoAction(Timeline timeline) {
 			affectedTargets.ForEach(targetData => {


### PR DESCRIPTION
This PR fixes #14 by reworking how actions are used in NotReaper.

Previously, the timeline would modify targets, then generate an action to undo/redo whatever it did. Unfortunately, many of the target references would get messed up by other actions when chaining many of them together.

This new system makes it so the action is responsible for both the forward action (like when the user initiates it, or on a re-do) and the backwards action. Because of this, the timeline now just generates actions and adds them to the queue.

These actions also now hold onto `TargetData`, which is a small set of data that represents a target. Actions can use these to instantiate Targets, or to find a target in the timeline that matches its data.

Since actions now own their own flow, they can modify their data in order to re-find targets even through long undo/redo chains. For example, `NRActionGridMoveNotes` moves their notes to the destination position, then sets all of their `TargetData` to point at that new position, so when they undo it will always find the correct note.

Along with this PR is some cleanup of state associated with the old action system, since we always generate actions from the timeline, and there is never a case where we wouldn't want to clear the redo stack when adding an action.

## Undo/Redo in action
![undoredo](https://user-images.githubusercontent.com/830434/65118072-853e7080-d99f-11e9-9375-ff4f60dae3cf.gif)
