### PR TITLE
Loading of bpm from midi

### DIFF
--- a/Assets/Scripts/IO/AudicaHandler.cs
+++ b/Assets/Scripts/IO/AudicaHandler.cs
@@ -3,6 +3,8 @@ using System.Collections;
 using System.IO;
 using System.Text;
 using Ionic.Zip;
+using Melanchall.DryWetMidi.Smf;
+using Melanchall.DryWetMidi.Smf.Interaction;
 using NotReaper.Models;
 using UnityEngine;
 using UnityEngine.Networking;
@@ -14,9 +16,6 @@ namespace NotReaper.IO {
 		public static AudicaFile LoadAudicaFile(string path) {
 
 			AudicaFile audicaFile = new AudicaFile();
-
-			
-
 			ZipFile audicaZip = ZipFile.Read(path);
 
 			string appPath = Application.dataPath;
@@ -56,16 +55,12 @@ namespace NotReaper.IO {
 				} else if (entry.FileName == "beginner.cues") {
 					entry.Extract($"{appPath}/.cache");
 					easy = true;
-				}
-
+				} 
 			}
-
-			
 
 			//Now we fill the audicaFile var with all the things it needs.
 			//Remember, all props in audicaFile.desc refer to either moggsong or the name of the mogg.
 			//Real clips are stored in main audicaFile object.
-
 
 			//Load the cues files.
 			if (expert) {
@@ -97,6 +92,10 @@ namespace NotReaper.IO {
 				} else if (entry.FileName == audicaFile.desc.sustainSongRight) {
 					entry.Extract(temp);
 					audicaFile.desc.moggSustainSongRight = MoggSongParser.parse_metadata(Encoding.UTF8.GetString(temp.ToArray())) [0];
+					
+				} else if (entry.FileName == "song.mid") {
+					entry.Extract($"{appPath}/.cache", ExtractExistingFileAction.OverwriteSilently);
+					audicaFile.song_mid = MidiFile.Read($"{appPath}/.cache/song.mid");
 				}
 
 				temp.SetLength(0);
@@ -106,13 +105,13 @@ namespace NotReaper.IO {
 
 			bool mainSongCached = false, sustainRightCached = false, sustainLeftCached = false;
 
-			if (File.Exists($"{Application.dataPath}/.cache/{audicaFile.desc.cachedMainSong}.ogg"))
+			if (File.Exists($"{appPath}/.cache/{audicaFile.desc.cachedMainSong}.ogg"))
 				mainSongCached = true;
 
-			if (File.Exists($"{Application.dataPath}/.cache/{audicaFile.desc.cachedSustainSongRight}.ogg"))
+			if (File.Exists($"{appPath}/.cache/{audicaFile.desc.cachedSustainSongRight}.ogg"))
 				sustainRightCached = true;
 
-			if (File.Exists($"{Application.dataPath}/.cache/{audicaFile.desc.cachedSustainSongLeft}.ogg"))
+			if (File.Exists($"{appPath}/.cache/{audicaFile.desc.cachedSustainSongLeft}.ogg"))
 				sustainLeftCached = true;
 
 

--- a/Assets/Scripts/Models/AudicaModels.cs
+++ b/Assets/Scripts/Models/AudicaModels.cs
@@ -1,7 +1,7 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using Melanchall.DryWetMidi.Smf;
 
 namespace NotReaper.Models {
 
@@ -102,6 +102,7 @@ namespace NotReaper.Models {
 		public AudioClip song_extras;
 		public AudioClip song_sustain_l;
 		public AudioClip song_sustain_r;
+		public MidiFile song_mid;
 		public string filepath;
 
 	}

--- a/Assets/Scripts/Timeline.cs
+++ b/Assets/Scripts/Timeline.cs
@@ -1,13 +1,12 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
-using System.IO.Compression;
 using System.Linq;
-using System.Security.AccessControl;
-using System.Security.Principal;
 using DG.Tweening;
 using Michsky.UI.ModernUIPack;
+using Melanchall.DryWetMidi.Smf;
+using Melanchall.DryWetMidi.Smf.Interaction;
 using NotReaper.Grid;
 using NotReaper.IO;
 using NotReaper.Managers;
@@ -18,8 +17,8 @@ using NotReaper.UI;
 using NotReaper.UserInput;
 using SFB;
 using TMPro;
+using UnityEditor;
 using UnityEngine;
-using UnityEngine.Events;
 using UnityEngine.Networking;
 using UnityEngine.UI;
 
@@ -619,6 +618,7 @@ namespace NotReaper {
 
 		public void SetTimingModeStats(double newBPM, int tickOffset) {
 			DeleteAllTargets();
+
 			SetBPM((float) newBPM);
 
 			var cue = new Cue {
@@ -674,9 +674,21 @@ namespace NotReaper {
 				audicaFile = AudicaHandler.LoadAudicaFile(paths[0]);
 				PlayerPrefs.SetString("recentFile", paths[0]);
 			}
-
-			//SetOffset(0);
+			
 			desc = audicaFile.desc;
+			
+			// Get song BPM
+			if (audicaFile.song_mid != null) {
+				// TODO: Multi-bpm support :(
+				var midiBpm = audicaFile.song_mid.GetTempoMap().Tempo.AtTime(0).BeatsPerMinute;
+				if (midiBpm != desc.tempo) {
+					if (EditorUtility.DisplayDialog("BPM mismatch",
+						"Detected different BPM values in midi and song.desc. NotReaper does not currently support multi-bpm tracks.",
+						$"Use midi ({midiBpm})", $"Use song.desc ({desc.tempo})")) {
+						desc.tempo = midiBpm;
+					}
+				}
+			} 
 
 			//Update our discord presence
 			nrDiscordPresence.UpdatePresenceSongName(desc.title);


### PR DESCRIPTION
Fixes #38
This PR adds the midi file to the internal representation of an audica file and detects differences in bpm (at time 0) in the midi to the desc file. It presents the user with a choice of BPM on load. 