### PR TITLE
Bugfix #48: Timeline notes could not be found

### DIFF
--- a/Assets/Scripts/Timeline.cs
+++ b/Assets/Scripts/Timeline.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
@@ -153,6 +153,10 @@ namespace NotReaper {
 			//dir.Delete(true);
 		}
 
+		public void SortOrderedList() {
+			orderedNotes.Sort((left, right) =>  left.gridTargetIcon.transform.localPosition.z.CompareTo(right.gridTargetIcon.transform.localPosition.z));
+		}
+
 		public static int BinarySearchOrderedNotes(float cueTime)
 		{ 
 			int min = 0;
@@ -179,7 +183,7 @@ namespace NotReaper {
 		public Target FindNote(TargetData data) {
 			int idx = BinarySearchOrderedNotes(data.beatTime);
 			if(idx == -1) {
-				Debug.Log("Couldn't find note with time " + data.beatTime);
+				Debug.LogError("Couldn't find note with time " + data.beatTime);
 				return null;
 			}
 
@@ -196,7 +200,7 @@ namespace NotReaper {
 				
 			}
 
-			Debug.Log("Couldn't find note with time " + data.beatTime + " and index " + idx);
+			Debug.LogError("Couldn't find note with time " + data.beatTime + " and index " + idx);
 			return null;
 		}
 
@@ -443,6 +447,8 @@ namespace NotReaper {
 		}
 
 		public void MoveTimelineTargets(List<TargetMoveIntent> intents) {
+			SortOrderedList();
+
 			var action = new NRActionTimelineMoveNotes();
 			action.targetTimelineMoveIntents = intents.Select(intent => new TargetDataMoveIntent(intent)).ToList();
 			Tools.undoRedoManager.AddAction(action);

--- a/Assets/Scripts/Tools/UndoRedoManager.cs
+++ b/Assets/Scripts/Tools/UndoRedoManager.cs
@@ -162,10 +162,11 @@ namespace NotReaper.Tools {
 		public List<TargetDataMoveIntent> targetTimelineMoveIntents = new List<TargetDataMoveIntent>();
 
 		public override void DoAction(Timeline timeline) {
-			//timeline.Tools.dragSelect.EndAllDragStuff();
-			
-			targetTimelineMoveIntents.ForEach(intent => {
-				Target target = timeline.FindNote(intent.targetData);
+			List<Target> targets = targetTimelineMoveIntents.Select(intent => timeline.FindNote(intent.targetData)).ToList();
+
+			for(int i = 0; i < targetTimelineMoveIntents.Count; ++i) {
+				TargetDataMoveIntent intent = targetTimelineMoveIntents[i];
+				Target target = targets[i];
 				var newPos = intent.intendedPosition;
 
 				var gridPos = target.gridTargetIcon.transform.localPosition;
@@ -173,13 +174,15 @@ namespace NotReaper.Tools {
 				target.gridTargetIcon.transform.localPosition = new Vector3(gridPos.x, gridPos.y, newPos.x);
 				timeline.updateSustainEnd(target);
 				intent.targetData.beatTime = newPos.x;
-			});
+			}
+			timeline.SortOrderedList();
 		}
 		public override void UndoAction(Timeline timeline) {
-			//timeline.Tools.dragSelect.EndAllDragStuff();
-			
-			targetTimelineMoveIntents.ForEach(intent => {
-				Target target = timeline.FindNote(intent.targetData);
+			List<Target> targets = targetTimelineMoveIntents.Select(intent => timeline.FindNote(intent.targetData)).ToList();
+
+			for(int i = 0; i < targetTimelineMoveIntents.Count; ++i) {
+				TargetDataMoveIntent intent = targetTimelineMoveIntents[i];
+				Target target = targets[i];
 				var newPos = intent.startingPosition;
 
 				var gridPos = target.gridTargetIcon.transform.localPosition;
@@ -187,7 +190,8 @@ namespace NotReaper.Tools {
 				target.gridTargetIcon.transform.localPosition = new Vector3(gridPos.x, gridPos.y, newPos.x);
 				timeline.updateSustainEnd(target);
 				intent.targetData.beatTime = newPos.x;
-			});
+			}
+			timeline.SortOrderedList();
 		}
 	}
 


### PR DESCRIPTION
This PR fixes #48. Since we now use binary search to find notes, the ordered list has to be sorted at all times, otherwise some notes won't be able to be found.

The only time where this sorting becomes invalidated is when we are moving notes along the timeline, so we now sort before invoking the move action, and we sort after each move action do/undo.